### PR TITLE
Add Garden Chase Safari-friendly web game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Garden Chase</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page">
+      <section class="panel">
+        <h1>Garden Chase</h1>
+        <p class="instructions">
+          Catch as many fireflies as you can before the time runs out! Tap or
+          click the glowing firefly as soon as it appears.
+        </p>
+        <div class="hud">
+          <div><span class="label">Time:</span> <span id="time">30</span>s</div>
+          <div><span class="label">Score:</span> <span id="score">0</span></div>
+          <div>
+            <span class="label">Best:</span> <span id="best-score">0</span>
+          </div>
+        </div>
+        <button id="start" class="start">Start Game</button>
+      </section>
+
+      <section class="field" id="field" aria-label="Firefly hunting field">
+        <button class="firefly" id="firefly" aria-label="Firefly"></button>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,124 @@
+(function () {
+  var startButton = document.getElementById("start");
+  var field = document.getElementById("field");
+  var firefly = document.getElementById("firefly");
+  var timeDisplay = document.getElementById("time");
+  var scoreDisplay = document.getElementById("score");
+  var bestDisplay = document.getElementById("best-score");
+
+  var timeLeft = 30;
+  var score = 0;
+  var bestScore = 0;
+  var timerId = null;
+  var gameActive = false;
+
+  function resizeFirefly() {
+    var size = Math.max(36, Math.min(field.offsetWidth, field.offsetHeight) * 0.12);
+    firefly.style.width = size + "px";
+    firefly.style.height = size + "px";
+  }
+
+  function randomPosition() {
+    var fieldRect = field.getBoundingClientRect();
+    var flyRect = firefly.getBoundingClientRect();
+
+    var maxX = fieldRect.width - flyRect.width;
+    var maxY = fieldRect.height - flyRect.height;
+
+    var x = Math.random() * maxX;
+    var y = Math.random() * maxY;
+
+    firefly.style.transform = "translate(" + x + "px, " + y + "px)";
+  }
+
+  function setTime(seconds) {
+    timeLeft = seconds;
+    timeDisplay.textContent = seconds;
+  }
+
+  function updateScore(value) {
+    score = value;
+    scoreDisplay.textContent = value;
+  }
+
+  function startGame() {
+    if (gameActive) {
+      return;
+    }
+
+    gameActive = true;
+    setTime(30);
+    updateScore(0);
+    startButton.disabled = true;
+    firefly.classList.add("visible");
+    randomPosition();
+
+    timerId = window.setInterval(function () {
+      timeLeft -= 1;
+      timeDisplay.textContent = timeLeft;
+
+      if (timeLeft <= 0) {
+        endGame();
+      }
+    }, 1000);
+  }
+
+  function endGame() {
+    if (!gameActive) {
+      return;
+    }
+
+    gameActive = false;
+    window.clearInterval(timerId);
+    timerId = null;
+    startButton.disabled = false;
+    firefly.classList.remove("visible");
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestDisplay.textContent = bestScore;
+      try {
+        window.localStorage.setItem("gardenChaseBest", String(bestScore));
+      } catch (e) {
+        // localStorage might be unavailable; fail silently.
+      }
+    }
+  }
+
+  function handleHit(event) {
+    if (!gameActive) {
+      return;
+    }
+
+    event.preventDefault();
+    updateScore(score + 1);
+    randomPosition();
+  }
+
+  function restoreBestScore() {
+    try {
+      var saved = window.localStorage.getItem("gardenChaseBest");
+      if (saved) {
+        bestScore = parseInt(saved, 10) || 0;
+        bestDisplay.textContent = bestScore;
+      }
+    } catch (e) {
+      // Ignore storage access issues.
+    }
+  }
+
+  startButton.addEventListener("click", startGame);
+  firefly.addEventListener("click", handleHit);
+  firefly.addEventListener("touchstart", handleHit);
+  window.addEventListener("resize", resizeFirefly);
+
+  document.addEventListener("visibilitychange", function () {
+    if (document.hidden) {
+      endGame();
+    }
+  });
+
+  resizeFirefly();
+  restoreBestScore();
+  randomPosition();
+})();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,144 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --panel-width: min(24rem, 90vw);
+  --field-size: min(26rem, 90vw);
+  --bg: #0c1321;
+  --panel-bg: rgba(255, 255, 255, 0.85);
+  --text: #0c1321;
+  --accent: #f7b500;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: radial-gradient(circle at top, #1c2639, #060910 75%);
+  color: var(--text);
+}
+
+body.dark {
+  --panel-bg: rgba(18, 26, 42, 0.85);
+  --text: #f5f7ff;
+}
+
+.page {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+  align-items: stretch;
+  padding: 2rem 1rem;
+}
+
+.panel {
+  width: var(--panel-width);
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: var(--panel-bg);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.25);
+}
+
+.panel h1 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.instructions {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.hud {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 1.25rem 0;
+  font-size: 1.1rem;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.start {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 1.1rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(90deg, #f9d423, #ff4e50);
+  color: #0c1321;
+  font-weight: 700;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.start:focus,
+.start:hover {
+  outline: none;
+  transform: translateY(-2px);
+  box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.3);
+}
+
+.start:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.field {
+  position: relative;
+  width: var(--field-size);
+  height: var(--field-size);
+  border-radius: 1.25rem;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.25), transparent 60%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.2), transparent 40%),
+    rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+}
+
+.firefly {
+  position: absolute;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9) 0%, rgba(247, 181, 0, 0.75) 60%, rgba(247, 181, 0, 0) 70%);
+  box-shadow: 0 0 1.5rem rgba(247, 181, 0, 0.8);
+  transition: transform 0.1s ease, opacity 0.25s ease;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.firefly:active {
+  transform: scale(0.9);
+}
+
+.firefly.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (max-width: 600px) {
+  .hud {
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .instructions {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- create a simple "Garden Chase" reflex game with score and timer tracking
- style the play field and controls with a responsive, touch-friendly layout
- implement Safari-compatible JavaScript logic including local high score persistence

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e27a4df6308330be3b84579ef13c31